### PR TITLE
Try linking against the .lib file on Windows

### DIFF
--- a/ep_testing/tester.py
+++ b/ep_testing/tester.py
@@ -34,15 +34,10 @@ class Tester:
         TransitionOldFile().run(
             self.install_path, self.verbose, {'last_version': self.config.tag_last_version}
         )
-        # to use the DLL at link-time, Windows requires the lib file, so just build this on Mac/Linux
-        if system() == 'Linux' or system() == 'Darwin':  # windows needs lib or def
-            TestCAPIAccess().run(
-                self.install_path, self.verbose, {}
-            )
-        else:
-            if self.verbose:
-                print("Building against the DLL at link time on Linux/Mac ONLY until we get a .lib file")
-        # however, linking at run-time works just fine on all three platforms
+        # linking to DLL at build time and delayed works on all platforms
+        TestCAPIAccess().run(
+            self.install_path, self.verbose, {}
+        )
         TestCppAPIDelayedAccess().run(
             self.install_path, self.verbose, {}
         )

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -102,6 +102,7 @@ class TestCAPIAccess(BaseTest):
             lib_file_name = 'libenergyplusapi.dylib'
         else:  # windows
             lib_file_name = 'energyplusapi.lib'
+            install_path = install_path.replace('\\', '\\\\')
         return """
 cmake_minimum_required(VERSION 3.10)
 project({TARGET_NAME})

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -162,7 +162,8 @@ int main() {
                     check_call(command_line, cwd=install_root, stdout=dev_null, stderr=STDOUT)
             elif platform.system() == 'Windows':
                 # for Windows, we just need to make sure to append .exe
-                new_binary_path = os.path.join(cmake_build_dir, self.target_name + '.exe')
+                new_binary_path = os.path.join(cmake_build_dir, 'Release', self.target_name + '.exe')
+                print("Trying to run binary at: " + new_binary_path)
                 command_line = [new_binary_path]
                 if self.verbose:
                     check_call(command_line, cwd=install_root)

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -101,7 +101,7 @@ class TestCAPIAccess(BaseTest):
         elif platform.system() == 'Darwin':
             lib_file_name = 'libenergyplusapi.dylib'
         else:  # windows
-            raise EPTestingException('This doesnt work on windows yet')
+            lib_file_name = 'energyplusapi.lib'
         return """
 cmake_minimum_required(VERSION 3.10)
 project({TARGET_NAME})
@@ -151,7 +151,7 @@ int main() {
         cmake_build_dir = os.path.join(build_dir, 'build')
         make_build_dir_and_build(cmake_build_dir, self.verbose)
         try:
-            if platform.system() == 'Linux':
+            if platform.system() == 'Linux' or platform.system() == 'Windows':
                 # for Linux, we don't have to do anything, just run it
                 new_binary_path = os.path.join(cmake_build_dir, self.target_name)
                 command_line = [new_binary_path]

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -163,7 +163,6 @@ int main() {
             elif platform.system() == 'Windows':
                 # for Windows, we just need to make sure to append .exe
                 new_binary_path = os.path.join(cmake_build_dir, 'Release', self.target_name + '.exe')
-                print("Trying to run binary at: " + new_binary_path)
                 command_line = [new_binary_path]
                 if self.verbose:
                     check_call(command_line, cwd=install_root)

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -152,9 +152,17 @@ int main() {
         cmake_build_dir = os.path.join(build_dir, 'build')
         make_build_dir_and_build(cmake_build_dir, self.verbose)
         try:
-            if platform.system() == 'Linux' or platform.system() == 'Windows':
+            if platform.system() == 'Linux':
                 # for Linux, we don't have to do anything, just run it
                 new_binary_path = os.path.join(cmake_build_dir, self.target_name)
+                command_line = [new_binary_path]
+                if self.verbose:
+                    check_call(command_line, cwd=install_root)
+                else:
+                    check_call(command_line, cwd=install_root, stdout=dev_null, stderr=STDOUT)
+            elif platform.system() == 'Windows':
+                # for Windows, we just need to make sure to append .exe
+                new_binary_path = os.path.join(cmake_build_dir, self.target_name + '.exe')
                 command_line = [new_binary_path]
                 if self.verbose:
                     check_call(command_line, cwd=install_root)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class Runner(distutils.cmd.Command):
         pass
 
     def run(self):
-        verbose = True
+        verbose = False
         c = TestConfiguration()
         self.announce('Attempting to test tag name: %s' % c.tag_this_version, level=distutils.log.INFO)
         d = Downloader(c, self.announce)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class Runner(distutils.cmd.Command):
         pass
 
     def run(self):
-        verbose = False
+        verbose = True
         c = TestConfiguration()
         self.announce('Attempting to test tag name: %s' % c.tag_this_version, level=distutils.log.INFO)
         d = Downloader(c, self.announce)


### PR DESCRIPTION
Yeah, I didn't realize we actually *were* packaging up the `energyplusapi.lib` file on Windows, so I should be able to link to that at build time and be all set with API calls on all platforms -- both this method and with delayed linking.