### PR TITLE
Add symlink testing

### DIFF
--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -14,7 +14,7 @@ class TestConfiguration:
 
         # If this is turned on, it expects to find an asset named target_file_name in the download_dir
         self.skip_download = True
-        self.skipped_download_file = '/eplus/repos/6eplus/builds/r/EnergyPlus-9.4.0-7def4cec5e-Linux-x86_64.tar.gz'
+        self.skipped_download_file = '/var/folders/1b/glc4bp3s2s52xb8vdgsj4qsw5dydhj/T/tmpy9_mlk48/ep.tar.gz'
 
         # But if we are on Travis, we override it to always download a new asset
         if os.environ.get('TRAVIS'):

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import shutil
 from tempfile import mkdtemp
 
 
@@ -6,19 +8,23 @@ class TestConfiguration:
 
     def __init__(self):
         self.this_version = '9.4'
-        self.tag_this_version = 'v9.4.0-TestSymlinkFix'
+        self.tag_this_version = 'v9.4.0-TestSymlinkFix2'
         self.last_version = '9.3'
         self.tag_last_version = 'v9.3.0'
 
         # If this is turned on, it expects to find an asset named target_file_name in the download_dir
         self.skip_download = True
-        self.skipped_download_dir = '/tmp/'
+        self.skipped_download_file = '/eplus/repos/6eplus/builds/r/EnergyPlus-9.4.0-7def4cec5e-Linux-x86_64.tar.gz'
 
         # But if we are on Travis, we override it to always download a new asset
         if os.environ.get('TRAVIS'):
             self.skip_download = False
 
+        self.download_dir = mkdtemp()
         if self.skip_download:
-            self.download_dir = self.skipped_download_dir
-        else:
-            self.download_dir = mkdtemp()
+            this_platform = platform.system()
+            target_file_name = 'ep.tar.gz'
+            if this_platform == 'Windows':
+                target_file_name = 'ep.zip'
+            file_path = os.path.join(self.download_dir, target_file_name)
+            shutil.copy(self.skipped_download_file, file_path)

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -5,10 +5,10 @@ from tempfile import mkdtemp
 class TestConfiguration:
 
     def __init__(self):
-        self.this_version = '9.3'
-        self.tag_this_version = 'v9.3.0-BugFix'
-        self.last_version = '9.2'
-        self.tag_last_version = 'v9.2.0'
+        self.this_version = '9.4'
+        self.tag_this_version = 'v9.4.0-TestSymlinkFix'
+        self.last_version = '9.3'
+        self.tag_last_version = 'v9.3.0'
 
         # If this is turned on, it expects to find an asset named target_file_name in the download_dir
         self.skip_download = True

--- a/ep_testing/tester.py
+++ b/ep_testing/tester.py
@@ -33,6 +33,9 @@ class Tester:
         TransitionOldFile().run(
             self.install_path, self.verbose, {'last_version': self.config.tag_last_version}
         )
+        TestPlainDDRunEPlusFile().run(
+            self.install_path, self.verbose, {'test_file': '1ZoneUncontrolled.idf', 'binary_sym_link': True}
+        )
         # linking to DLL at build time and delayed works on all platforms
         TestCAPIAccess().run(
             self.install_path, self.verbose, {}

--- a/ep_testing/tester.py
+++ b/ep_testing/tester.py
@@ -33,22 +33,20 @@ class Tester:
         TransitionOldFile().run(
             self.install_path, self.verbose, {'last_version': self.config.tag_last_version}
         )
-        TestPlainDDRunEPlusFile().run(
-            self.install_path, self.verbose, {'test_file': '1ZoneUncontrolled.idf', 'binary_sym_link': True}
-        )
-        # linking to DLL at build time and delayed works on all platforms
+        if system() == 'Windows':
+            if self.verbose:
+                print("Symlink runs are not testable on Travis, I think the user doesn't have symlink privilege.")
+        else:
+            TestPlainDDRunEPlusFile().run(
+                self.install_path, self.verbose, {'test_file': '1ZoneUncontrolled.idf', 'binary_sym_link': True}
+            )
         TestCAPIAccess().run(
             self.install_path, self.verbose, {}
         )
         TestCppAPIDelayedAccess().run(
             self.install_path, self.verbose, {}
         )
-        # Python may have trouble on Mac for right now, but should be able to work on Windows and Linux
-        if system() == 'Linux' or system() == 'Windows':
-            TestPythonAPIAccess().run(
-                self.install_path, self.verbose, {}
-            )
-        else:
-            if self.verbose:
-                print("Running Python API Linux and Windows ONLY until we get the @executable_path resolved on Mac")
+        TestPythonAPIAccess().run(
+            self.install_path, self.verbose, {}
+        )
         os.chdir(saved_path)

--- a/ep_testing/tests/energyplus.py
+++ b/ep_testing/tests/energyplus.py
@@ -18,8 +18,14 @@ class TestPlainDDRunEPlusFile(BaseTest):
         eplus_binary = os.path.join(install_root, 'energyplus')
         idf_path = os.path.join(install_root, 'ExampleFiles', test_file)
         dev_null = open(os.devnull, 'w')
+        if 'binary_sym_link' in kwargs:
+            eplus_binary_to_use = os.path.join(os.getcwd(), 'ep_symlink')
+            print("Making symlink at " + eplus_binary_to_use)
+            os.symlink(eplus_binary, eplus_binary_to_use)
+        else:
+            eplus_binary_to_use = eplus_binary
         try:
-            check_call([eplus_binary, '-D', idf_path], stdout=dev_null, stderr=STDOUT)
+            check_call([eplus_binary_to_use, '-D', idf_path], stdout=dev_null, stderr=STDOUT)
             print(' [DONE]!')
         except CalledProcessError:
             raise EPTestingException('EnergyPlus failed!')

--- a/ep_testing/tests/energyplus.py
+++ b/ep_testing/tests/energyplus.py
@@ -20,7 +20,10 @@ class TestPlainDDRunEPlusFile(BaseTest):
         dev_null = open(os.devnull, 'w')
         if 'binary_sym_link' in kwargs:
             eplus_binary_to_use = os.path.join(os.getcwd(), 'ep_symlink')
-            print("Making symlink at " + eplus_binary_to_use)
+            if verbose:
+                print(f' [SYM-LINKED at {eplus_binary_to_use}]', end='')
+            else:
+                print(' [SYM-LINKED]', end='')
             os.symlink(eplus_binary, eplus_binary_to_use)
         else:
             eplus_binary_to_use = eplus_binary

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class Runner(distutils.cmd.Command):
         pass
 
     def run(self):
-        verbose = True
+        verbose = False
         c = TestConfiguration()
         self.announce('Attempting to test tag name: %s' % c.tag_this_version, level=distutils.log.INFO)
         d = Downloader(c, self.announce)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class Runner(distutils.cmd.Command):
         pass
 
     def run(self):
-        verbose = False
+        verbose = True
         c = TestConfiguration()
         self.announce('Attempting to test tag name: %s' % c.tag_this_version, level=distutils.log.INFO)
         d = Downloader(c, self.announce)


### PR DESCRIPTION
Fixes #11 

It was found that on Mac, when you try to run E+ by installed symlinks, E+ won't run.  This is because of a problem with how the program finds the directory of the current running image path.  On Mac it doesn't follow the symlink so it returns the symlink directory, and so the lazy python wrapper can't be found.  This exercises that issue.