### PR TITLE
Prep for 24.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,9 +32,7 @@ jobs:
           python-version: '3.12'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-#      - name: Setup upterm session
-#        uses: lhotari/action-upterm@v1
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
       - name: Run Tests
         run: python3 setup.py run --run-config ${{ matrix.key }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.12'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
       #- name: Setup upterm session

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,10 +10,12 @@ jobs:
 #            key: ubuntu2004
 #          - os: ubuntu-22.04
 #            key: ubuntu2204
-          - os: macos-11
-            key: mac11
           - os: macos-12
             key: mac12
+#          - os: macos-13
+#            key: mac12
+          - os: macos-14
+            key: mac13-arm64
 #          - os: windows-2019
 #            key: win64
 #          - os: windows-2019  -- GitHub Action image doesn't have 32-bit compiler by default, remove 32-bit soon, ok?

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
         run: pip3 install -r requirements.txt
 #      - name: Setup tmate session
 #        uses: mxschmitt/action-tmate@v3
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+#      - name: Setup upterm session
+#        uses: lhotari/action-upterm@v1
       - name: Run Tests
         run: python3 setup.py run --run-config ${{ matrix.key }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
             key: mac12
 #          - os: macos-13
 #            key: mac12
-          - os: macos-13
+          - os: macos-14
             key: mac12-arm64
 #          - os: macos-14
 #            key: mac13-arm64

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.10'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
 #      - name: Setup tmate session

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.8'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
 #      - name: Setup tmate session

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.12'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
 #      - name: Setup tmate session

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,24 +6,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - os: ubuntu-20.04
-#            key: ubuntu2004
-#          - os: ubuntu-22.04
-#            key: ubuntu2204
+          - os: ubuntu-20.04
+            key: ubuntu2004
+          - os: ubuntu-22.04
+            key: ubuntu2204
+          - os: macos-11
+            key: mac11
           - os: macos-12
             key: mac12
 #          - os: macos-13
 #            key: mac12
-          - os: macos-14
-            key: mac12-arm64
+#          - os: macos-14
+#            key: mac12-arm64
 #          - os: macos-14
 #            key: mac13-arm64
-#          - os: windows-2019
-#            key: win64
+          - os: windows-2019
+            key: win64
 #          - os: windows-2019  -- GitHub Action image doesn't have 32-bit compiler by default, remove 32-bit soon, ok?
 #            key: win32
-#          - os: windows-2022
-#            key: win64-2022server
+          - os: windows-2022
+            key: win64-2022server
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,8 +32,8 @@ jobs:
           python-version: '3.12'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 #      - name: Setup upterm session
 #        uses: lhotari/action-upterm@v1
       - name: Run Tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.8'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
 #      - name: Setup tmate session

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,8 +14,10 @@ jobs:
             key: mac12
 #          - os: macos-13
 #            key: mac12
-          - os: macos-14
-            key: mac13-arm64
+          - os: macos-13
+            key: mac12-arm64
+#          - os: macos-14
+#            key: mac13-arm64
 #          - os: windows-2019
 #            key: win64
 #          - os: windows-2019  -- GitHub Action image doesn't have 32-bit compiler by default, remove 32-bit soon, ok?

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,20 +6,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            key: ubuntu2004
-          - os: ubuntu-22.04
-            key: ubuntu2204
+#          - os: ubuntu-20.04
+#            key: ubuntu2004
+#          - os: ubuntu-22.04
+#            key: ubuntu2204
           - os: macos-11
             key: mac11
           - os: macos-12
             key: mac12
-          - os: windows-2019
-            key: win64
+#          - os: windows-2019
+#            key: win64
 #          - os: windows-2019  -- GitHub Action image doesn't have 32-bit compiler by default, remove 32-bit soon, ok?
 #            key: win32
-          - os: windows-2022
-            key: win64-2022server
+#          - os: windows-2022
+#            key: win64-2022server
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -30,7 +30,9 @@ jobs:
           python-version: '3.12'
       - name: Install Dependencies
         run: pip3 install -r requirements.txt
-      #- name: Setup upterm session
-      #  uses: lhotari/action-upterm@v1
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Run Tests
         run: python3 setup.py run --run-config ${{ matrix.key }}

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.12'
     - name: Install Pip Dependencies
       run: pip install flake8
     - name: Run Flake8

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -18,8 +18,8 @@ CONFIGURATIONS = {
     'mac12': {
         'os': OS.Mac, 'bitness': 'x64', 'asset_pattern': 'Darwin-macOS12.1-x86_64.tar.gz', 'os_version': '12.1'
     },
-    'mac12-arm64': {
-        'os': OS.Mac, 'bitness': 'arm64', 'asset_pattern': 'Darwin-macOS12.1-arm64.tar.gz', 'os_version': '12.1'
+    'mac13-arm64': {
+        'os': OS.Mac, 'bitness': 'arm64', 'asset_pattern': 'Darwin-macOS13-arm64.tar.gz', 'os_version': '13'
     },
     'win32': {
         'os': OS.Windows, 'bitness': 'x32', 'asset_pattern': 'Windows-i386.zip', 'os_version': '10'

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -55,6 +55,6 @@ class TestConfiguration:
         self.bitness = this_config['bitness']
 
         self.this_version = '24.1'
-        self.tag_this_version = 'v24.1.0-IOFreeze'  # 'v24.1.0'
+        self.tag_this_version = 'v24.1.0-DisableARMonGHA'
         self.last_version = '23.2'
         self.tag_last_version = 'v23.2.0'

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -55,6 +55,6 @@ class TestConfiguration:
         self.bitness = this_config['bitness']
 
         self.this_version = '24.1'
-        self.tag_this_version = 'v24.1.0-DisableARMonGHA'
+        self.tag_this_version = 'v24.1.0-RC2'
         self.last_version = '23.2'
         self.tag_last_version = 'v23.2.0'

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -18,6 +18,9 @@ CONFIGURATIONS = {
     'mac12': {
         'os': OS.Mac, 'bitness': 'x64', 'asset_pattern': 'Darwin-macOS12.1-x86_64.tar.gz', 'os_version': '12.1'
     },
+    'mac12-arm64': {
+        'os': OS.Mac, 'bitness': 'arm64', 'asset_pattern': 'Darwin-macOS12.1-arm64.tar.gz', 'os_version': '12'
+    },
     'mac13-arm64': {
         'os': OS.Mac, 'bitness': 'arm64', 'asset_pattern': 'Darwin-macOS13-arm64.tar.gz', 'os_version': '13'
     },
@@ -52,6 +55,6 @@ class TestConfiguration:
         self.bitness = this_config['bitness']
 
         self.this_version = '24.1'
-        self.tag_this_version = 'v24.1.0-TestBuildWithPython312Again'  # 'v24.1.0'
+        self.tag_this_version = 'v24.1.0-IOFreeze'  # 'v24.1.0'
         self.last_version = '23.2'
         self.tag_last_version = 'v23.2.0'

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -52,6 +52,6 @@ class TestConfiguration:
         self.bitness = this_config['bitness']
 
         self.this_version = '24.1'
-        self.tag_this_version = 'v24.1.0-TestBuildWithPython312'  # 'v24.1.0'
+        self.tag_this_version = 'v24.1.0-TestBuildWithPython312Again'  # 'v24.1.0'
         self.last_version = '23.2'
         self.tag_last_version = 'v23.2.0'

--- a/ep_testing/config.py
+++ b/ep_testing/config.py
@@ -51,7 +51,7 @@ class TestConfiguration:
         self.asset_pattern = this_config['asset_pattern']
         self.bitness = this_config['bitness']
 
-        self.this_version = '23.1'
-        self.tag_this_version = 'v23.1.0'
-        self.last_version = '22.2'
-        self.tag_last_version = 'v22.2.0'
+        self.this_version = '24.1'
+        self.tag_this_version = 'v24.1.0-TestBuildWithPython312'  # 'v24.1.0'
+        self.last_version = '23.2'
+        self.tag_last_version = 'v23.2.0'

--- a/ep_testing/downloader.py
+++ b/ep_testing/downloader.py
@@ -47,6 +47,8 @@ class Downloader:
                 raise EPTestingException('Could not find asset to download, has CI finished it yet?')
             self._download_asset(asset)
         self.extracted_install_path = self._extract_asset()
+        if config.os == OS.Mac:  # TODO: JUST TEMPORARY!!
+            check_call(['codesign', '--remove-signature', self.extracted_install_path + "/Python"])
 
     def _get_extract_vars(self, config) -> Tuple[str, str]:
         target_file_name = ''

--- a/ep_testing/downloader.py
+++ b/ep_testing/downloader.py
@@ -47,8 +47,8 @@ class Downloader:
                 raise EPTestingException('Could not find asset to download, has CI finished it yet?')
             self._download_asset(asset)
         self.extracted_install_path = self._extract_asset()
-        if config.os == OS.Mac:  # TODO: JUST TEMPORARY!!
-            check_call(['codesign', '--remove-signature', self.extracted_install_path + "/Python"])
+        # if config.os == OS.Mac:  # TODO: JUST TEMPORARY!!
+        #     check_call(['codesign', '--remove-signature', self.extracted_install_path + "/Python"])
 
     def _get_extract_vars(self, config) -> Tuple[str, str]:
         target_file_name = ''

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -77,8 +77,7 @@ class TestPythonAPIAccess(BaseTest):
                 my_env["PATH"] = install_root + ";" + my_env["PATH"]
             if self.os == OS.Mac:
                 # while it runs OK locally, for some reason on GHA, running a Plugin file from the Python API seg-faults
-                idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
-                # '1ZoneUncontrolled.idf')
+                idf_to_run = os.path.join(install_root, 'ExampleFiles', '1ZoneUncontrolled.idf')
             else:
                 idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
             my_check_call(self.verbose, [py, python_file_path, '-D', idf_to_run], env=my_env)

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -75,11 +75,11 @@ class TestPythonAPIAccess(BaseTest):
             my_env = os.environ.copy()
             if self.os == OS.Windows:  # my local comp didn't have cmake in path except in interact shells
                 my_env["PATH"] = install_root + ";" + my_env["PATH"]
-            if self.os == OS.Mac:
+            # if self.os == OS.Mac:
                 # while it runs OK locally, for some reason on GHA, running a Plugin file from the Python API seg-faults
-                idf_to_run = os.path.join(install_root, 'ExampleFiles', '1ZoneUncontrolled.idf')
-            else:
-                idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
+            idf_to_run = os.path.join(install_root, 'ExampleFiles', '1ZoneUncontrolled.idf')
+            # else:
+            #    idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
             my_check_call(self.verbose, [py, python_file_path, '-D', idf_to_run], env=my_env)
             print(' [DONE]!')
         except EPTestingException as e:

--- a/ep_testing/tests/api.py
+++ b/ep_testing/tests/api.py
@@ -75,11 +75,12 @@ class TestPythonAPIAccess(BaseTest):
             my_env = os.environ.copy()
             if self.os == OS.Windows:  # my local comp didn't have cmake in path except in interact shells
                 my_env["PATH"] = install_root + ";" + my_env["PATH"]
-            # if self.os == OS.Mac:
+            if self.os == OS.Mac:
                 # while it runs OK locally, for some reason on GHA, running a Plugin file from the Python API seg-faults
-            idf_to_run = os.path.join(install_root, 'ExampleFiles', '1ZoneUncontrolled.idf')
-            # else:
-            #    idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
+                idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
+                # '1ZoneUncontrolled.idf')
+            else:
+                idf_to_run = os.path.join(install_root, 'ExampleFiles', 'PythonPluginCustomOutputVariable.idf')
             my_check_call(self.verbose, [py, python_file_path, '-D', idf_to_run], env=my_env)
             print(' [DONE]!')
         except EPTestingException as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flake8
 requests
+
+setuptools


### PR DESCRIPTION
Main change - assuming a more modern Python -- 3.12.  For almost all users everywhere, this will not be a problem.  For those people who want to use Python API to run EnergyPlus files which may also include Python Plugin files inside ---- they may want to change.